### PR TITLE
feat: follow vscode's theme automatically

### DIFF
--- a/src/theme-vscode/color.d.ts
+++ b/src/theme-vscode/color.d.ts
@@ -1,0 +1,3 @@
+import { ThemePack } from '@milkdown/design-system';
+export declare const color: ThemePack['color'];
+//# sourceMappingURL=nord.d.ts.map

--- a/src/theme-vscode/color.js
+++ b/src/theme-vscode/color.js
@@ -1,0 +1,36 @@
+const varMap = {}
+
+/**
+ * hack for accessing theme's colors programmatically
+ * https://github.com/microsoft/vscode/issues/32813#issuecomment-798680103
+ */
+Object.values(document.getElementsByTagName('html')[0].style)
+    .map(
+        (rv) => {
+            return {
+                [rv]: document
+                    .getElementsByTagName('html')[0]
+                    .style.getPropertyValue(rv),
+            }
+        }
+    )
+    .forEach(varObj => {
+        for (let key in varObj) {
+            if (varObj[key]) {
+                varMap[key] = varObj[key]
+            }
+        }
+    })
+
+
+// use #000000 as default value for high contrast theme
+export const color = {
+    shadow: varMap['--vscode-widget-shadow'] || '#000000',
+    primary: varMap['--vscode-textBlockQuote-border'],
+    secondary: varMap['--vscode-textLink-foreground'],
+    neutral: varMap['--vscode-foreground'],
+    solid: varMap['--vscode-icon-foreground'],
+    line: varMap['--vscode-textBlockQuote-border'],
+    background: varMap['--vscode-textBlockQuote-background'] || '#000000',
+    surface: varMap['--vscode-editor-background'],
+};

--- a/src/theme-vscode/index.d.ts
+++ b/src/theme-vscode/index.d.ts
@@ -1,0 +1,2 @@
+export declare const vscode: import("@milkdown/core").MilkdownPlugin;
+//# sourceMappingURL=index.d.ts.map

--- a/src/theme-vscode/index.js
+++ b/src/theme-vscode/index.js
@@ -1,0 +1,101 @@
+import { injectGlobal } from '@emotion/css';
+import { themeFactory } from '@milkdown/core';
+import { color } from './color';
+import { view } from './view';
+import { widget } from './widget';
+
+export const vscode = themeFactory({
+    font: {
+        font: ['var(--vscode-font-family)'],
+        fontCode: ['var(--vscode-editor-font-family)'],
+    },
+    size: {
+        radius: '4px',
+        lineWidth: '1px',
+    },
+    color,
+    widget,
+    global: ({ palette, font, widget, size }) => {
+        var _a, _b;
+        const css = injectGlobal;
+        css`
+            ${view};
+            .milkdown {
+                // color: ${palette('neutral')};
+                background: ${palette('surface')};
+
+                position: relative;
+                font-family: ${font.font};
+                margin-left: auto;
+                margin-right: auto;
+                ${(_a = widget.shadow) === null || _a === void 0 ? void 0 : _a.call(widget)};
+                padding: 1.25rem;
+                box-sizing: border-box;
+
+                .editor {
+                    outline: none;
+                    & > * {
+                        margin: 1.875rem 0;
+                    }
+                    h1, h2, h3, h4, h5, h6 {
+                        margin-top: 24px!important;
+                        margin-bottom: 16px!important;
+                        font-weight: 600;
+                        line-height: 1.25;
+                    }
+                    h1 {
+                        padding-bottom: 0.3em;
+                        font-size: 2em;
+                    }
+                    h2 {
+                        padding-bottom: 0.3em;
+                        font-size: 1.5em;
+                    }
+                    h3 {
+                        font-size: 1.25em;
+                    }
+                    h4 {
+                        font-size: 1em;
+                    }
+                    h5, h6 {
+                        font-size: 0.875em;
+                    }
+                    .code-fence {
+                        background: var(--vscode-textCodeBlock-background);
+                    }
+                    blockquote {
+                        border-left: 4px solid var(--vscode-textBlockQuote-border);
+                    }
+                    .code-inline {
+                        color: var(--vscode-textPreformat-foreground);
+                        background-color: var(--vscode-textBlockQuote-background);
+                    }
+                }
+                .ProseMirror.editor > :first-child {
+                    margin-top: 0!important;
+                }
+
+                .ProseMirror-selectednode {
+                    outline: ${size.lineWidth} solid ${palette('line')};
+                }
+
+                li.ProseMirror-selectednode {
+                    outline: none;
+                }
+
+                li.ProseMirror-selectednode::after {
+                    ${(_b = widget.border) === null || _b === void 0 ? void 0 : _b.call(widget)}
+                }
+
+                @media only screen and (min-width: 72rem) {
+                    max-width: 57.375rem;
+                    padding: 3.125rem 7.25rem;
+                }
+
+                & ::selection {
+                    background: ${palette('secondary', 0.38)};
+                }
+            }
+        `;
+    },
+});

--- a/src/theme-vscode/view.d.ts
+++ b/src/theme-vscode/view.d.ts
@@ -1,0 +1,2 @@
+export declare const view: string;
+//# sourceMappingURL=view.d.ts.map

--- a/src/theme-vscode/view.js
+++ b/src/theme-vscode/view.js
@@ -1,0 +1,55 @@
+import { css } from '@emotion/css';
+export const view = css`
+    /* copy from https://github.com/ProseMirror/prosemirror-view/blob/master/style/prosemirror.css */
+    .ProseMirror {
+        position: relative;
+    }
+
+    .ProseMirror {
+        word-wrap: break-word;
+        white-space: pre-wrap;
+        white-space: break-spaces;
+        -webkit-font-variant-ligatures: none;
+        font-variant-ligatures: none;
+        font-feature-settings: 'liga' 0; /* the above doesn't seem to work in Edge */
+    }
+
+    .ProseMirror pre {
+        white-space: pre-wrap;
+    }
+
+    .ProseMirror li {
+        position: relative;
+    }
+
+    .ProseMirror-hideselection *::selection {
+        background: transparent;
+    }
+    .ProseMirror-hideselection *::-moz-selection {
+        background: transparent;
+    }
+    .ProseMirror-hideselection {
+        caret-color: transparent;
+    }
+
+    .ProseMirror-selectednode {
+        outline: 2px solid #8cf;
+    }
+
+    /* Make sure li selections wrap around markers */
+
+    li.ProseMirror-selectednode {
+        outline: none;
+    }
+
+    li.ProseMirror-selectednode:after {
+        content: '';
+        position: absolute;
+        left: -32px;
+        right: -2px;
+        top: -2px;
+        bottom: -2px;
+        border: 2px solid #8cf;
+        pointer-events: none;
+    }
+`;

--- a/src/theme-vscode/widget.d.ts
+++ b/src/theme-vscode/widget.d.ts
@@ -1,0 +1,3 @@
+import { ThemePack } from '@milkdown/design-system';
+export declare const widget: ThemePack['widget'];
+//# sourceMappingURL=widget.d.ts.map

--- a/src/theme-vscode/widget.js
+++ b/src/theme-vscode/widget.js
@@ -1,0 +1,65 @@
+import { css } from '@emotion/css';
+export const widget = ({ palette, size }) => ({
+    icon: (key) => css`
+        content: '${key}';
+
+        font-family: 'Material Icons Outlined';
+        font-weight: normal;
+        font-style: normal;
+        font-size: 1.5rem;
+        line-height: 1;
+        text-transform: none;
+        letter-spacing: normal;
+        word-wrap: normal;
+        white-space: nowrap;
+        display: inline-block;
+        direction: ltr;
+
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        -moz-osx-font-smoothing: grayscale;
+        font-feature-settings: liga;
+    `,
+    scrollbar: (direction = 'y') => css`
+        scrollbar-width: thin;
+        scrollbar-color: ${palette('secondary', 0.38)} ${palette('secondary', 0.12)};
+        -webkit-overflow-scrolling: touch;
+
+        &::-webkit-scrollbar {
+            ${direction === 'y' ? 'width' : 'height'}: 4px;
+            padding: 0 2px;
+            background: ${palette('surface')};
+        }
+
+        &::-webkit-scrollbar-track {
+            border-radius: 4px;
+            background: ${palette('secondary', 0.12)};
+        }
+
+        &::-webkit-scrollbar-thumb {
+            border-radius: 4px;
+            background: ${palette('secondary', 0.38)};
+        }
+
+        &::-webkit-scrollbar-thumb:hover {
+            background: ${palette('secondary')};
+        }
+    `,
+    shadow: () => {
+        const { lineWidth } = size;
+        return css`
+            box-shadow: 0px ${lineWidth} ${lineWidth} ${palette('shadow', 0.14)},
+                0px 2px ${lineWidth} ${palette('shadow', 0.12)}, 0px ${lineWidth} 3px ${palette('shadow', 0.2)};
+        `;
+    },
+    border: (direction) => {
+        if (!direction) {
+            return css`
+                border: ${size.lineWidth} solid ${palette('line')};
+            `;
+        }
+        return css`
+            ${`border-${direction}`}: ${size.lineWidth} solid ${palette('line')};
+        `;
+    },
+});

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -1,5 +1,5 @@
 import { Slice } from 'prosemirror-model';
-import { nord } from '@milkdown/theme-nord';
+import { vscode as vscodeTheme } from '../theme-vscode/index';
 import { Editor, rootCtx, editorViewCtx, parserCtx, defaultValueCtx } from '@milkdown/core';
 import { gfm } from '@milkdown/preset-gfm';
 import { tooltip } from '@milkdown/plugin-tooltip';
@@ -53,7 +53,7 @@ const createEditor = () =>
                 ],
             });
         })
-        .use(nord)
+        .use(vscodeTheme)
         .use(gfm)
         .use(slash)
         .use(tooltip)


### PR DESCRIPTION
# Overview
try to make milkdown-vscode follow user's color theme automatically, instead of using nord as deafult.

# Preview
## Light:
![image](https://user-images.githubusercontent.com/20593467/130346959-b815c507-1933-4246-ac83-9f7e6d4552bb.png)

## Dark:
![image](https://user-images.githubusercontent.com/20593467/130346982-56859025-f501-4abe-a31f-68345a64010d.png)

## Solarized Light:
![image](https://user-images.githubusercontent.com/20593467/130347050-5671c839-87f7-4fca-b57a-73447ed0f684.png)

## High contrast
![image](https://user-images.githubusercontent.com/20593467/130347080-355d8cdb-ff7d-4e68-b245-07dd76526033.png)

